### PR TITLE
determineBolusEventType

### DIFF
--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -211,6 +211,16 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
         }
     }
 
+    func determineBolusEventType(for event: PumpHistoryEvent) -> EventType {
+        if event.isSMB ?? false {
+            return .smb
+        }
+        if event.isNonPumpInsulin ?? false {
+            return .nonPumpInsulin
+        }
+        return event.type
+    }
+
     func nightscoutTretmentsNotUploaded() -> [NigtscoutTreatment] {
         let events = recent()
         guard !events.isEmpty else { return [] }
@@ -251,13 +261,14 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
         let bolusesAndCarbs = events.compactMap { event -> NigtscoutTreatment? in
             switch event.type {
             case .bolus:
+                let eventType = determineBolusEventType(for: event)
                 return NigtscoutTreatment(
                     duration: event.duration,
                     rawDuration: nil,
                     rawRate: nil,
                     absolute: nil,
                     rate: nil,
-                    eventType: (event.isSMB ?? false) ? .smb : (event.isNonPumpInsulin ?? false) ? .nonPumpInsulin : .bolus,
+                    eventType: eventType,
                     createdAt: event.timestamp,
                     enteredBy: NigtscoutTreatment.local,
                     bolus: event,


### PR DESCRIPTION
Summary
This PR refactors the nightscoutTreatmentsNotUploaded() function in the BasePumpHistoryStorage class. Specifically, it isolates the logic for determining the EventType for bolus events into a separate helper function named determineBolusEventType().

Motivation
The change aims to improve code maintainability and readability. Previously, the logic for determining the EventType for bolus events was embedded within the nightscoutTreatmentsNotUploaded() function. This led to a longer and more complex function, making it harder to understand and maintain.

Implementation Details
A new function, determineBolusEventType(for:), has been introduced. This function takes a PumpHistoryEvent as an argument and returns an EventType. The logic for determining the EventType has been moved from nightscoutTreatmentsNotUploaded() to this new function.

The line that previously determined the EventType within nightscoutTreatmentsNotUploaded() has been replaced by a call to determineBolusEventType(for:).

Expected Behavior
The behavior of the code should remain the same. This is a purely structural change aimed at improving code quality.